### PR TITLE
Enabled wifi support for some arduino boards #9

### DIFF
--- a/ArduinoOSC.h
+++ b/ArduinoOSC.h
@@ -13,7 +13,10 @@
 
 #if defined(ESP_PLATFORM)\
  || defined(ESP8266)\
- || defined(ARDUINO_ARCH_MEGAAVR)
+ || defined(ARDUINO_AVR_UNO_WIFI_REV2)\
+ || defined(ARDUINO_SAMD_MKRWIFI1010)\
+ || defined(ARDUINO_SAMD_MKRVIDOR4000)\
+ || defined(ARDUINO_SAMD_MKR1000)
     #define ARDUINOOSC_ENABLE_WIFI
 #endif
 
@@ -36,8 +39,15 @@
     #elif defined (ESP8266)
         #include <ESP8266WiFi.h>
         #include <WiFiUdp.h>
-    #elif defined (ARDUINO_ARCH_MEGAAVR)
+    #elif defined (ARDUINO_AVR_UNO_WIFI_REV2)\
+        || defined(ARDUINO_SAMD_MKRWIFI1010)\
+        || defined(ARDUINO_SAMD_MKRVIDOR4000)
+        #include <SPI.h>
         #include <WiFiNINA.h>
+        #include <WiFiUdp.h>
+    #elif defined (ARDUINO_SAMD_MKR1000)
+        #include <SPI.h>
+        #include <WiFi101.h>
         #include <WiFiUdp.h>
     #endif
 #endif // ARDUINOOSC_ENABLE_WIFI

--- a/ArduinoOSC.h
+++ b/ArduinoOSC.h
@@ -12,7 +12,8 @@
 #endif
 
 #if defined(ESP_PLATFORM)\
- || defined(ESP8266)
+ || defined(ESP8266)\
+ || defined(ARDUINO_ARCH_MEGAAVR)
     #define ARDUINOOSC_ENABLE_WIFI
 #endif
 
@@ -34,6 +35,9 @@
         #include <WiFiUdp.h>
     #elif defined (ESP8266)
         #include <ESP8266WiFi.h>
+        #include <WiFiUdp.h>
+    #elif defined (ARDUINO_ARCH_MEGAAVR)
+        #include <WiFiNINA.h>
         #include <WiFiUdp.h>
     #endif
 #endif // ARDUINOOSC_ENABLE_WIFI

--- a/ArduinoOSC.h
+++ b/ArduinoOSC.h
@@ -16,7 +16,8 @@
  || defined(ARDUINO_AVR_UNO_WIFI_REV2)\
  || defined(ARDUINO_SAMD_MKRWIFI1010)\
  || defined(ARDUINO_SAMD_MKRVIDOR4000)\
- || defined(ARDUINO_SAMD_MKR1000)
+ || defined(ARDUINO_SAMD_MKR1000)\
+ || defined(ARDUINO_SAMD_NANO_33_IOT)
     #define ARDUINOOSC_ENABLE_WIFI
 #endif
 
@@ -41,7 +42,8 @@
         #include <WiFiUdp.h>
     #elif defined (ARDUINO_AVR_UNO_WIFI_REV2)\
         || defined(ARDUINO_SAMD_MKRWIFI1010)\
-        || defined(ARDUINO_SAMD_MKRVIDOR4000)
+        || defined(ARDUINO_SAMD_MKRVIDOR4000)\
+        || defined(ARDUINO_SAMD_NANO_33_IOT)
         #include <SPI.h>
         #include <WiFiNINA.h>
         #include <WiFiUdp.h>

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Please feel free to send PR or request for more board support!
 
 - ESP32
 - ESP8266
+- Arduino Uno WiFi Rev2
+- Arduino MKR VIDOR 4000
+- Arduino MKR WiFi 1010
+- Arduino MKR WiFi 1000
 
 #### Ethernet
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Please feel free to send PR or request for more board support!
 - Arduino MKR VIDOR 4000
 - Arduino MKR WiFi 1010
 - Arduino MKR WiFi 1000
+- Arduino Nano 33 IoT
 
 #### Ethernet
 


### PR DESCRIPTION
I enabled wifi support for some arduino boards (Arduino UNO WiFi Rev.2, MKR WiFi 1010 ...) as described in #9 .

Not totally sure if they also could handle bundles, so I let it deactivated.